### PR TITLE
[Feat] Home 출발지 선택 모달

### DIFF
--- a/src/pages/home/components/DepartureModal.tsx
+++ b/src/pages/home/components/DepartureModal.tsx
@@ -1,0 +1,33 @@
+import location from '@/shared/assets/icons/location.svg';
+
+const departureLocations = ['인천/김포', '부산', '대구', '청주', '제주', '양양'] as const;
+
+const DepartureModal = () => {
+  const handleClicklocation = (location: string) => {
+    console.log('출발지 선택', location);
+  };
+
+  return (
+    <div className="border-purple100 w-[34.2rem] overflow-hidden rounded-[0.5rem] border">
+      <div className="flex items-center gap-[0.8rem] px-[1.6rem] py-[2.1rem]">
+        <img src={location} alt="위치 아이콘" className="text-gray600 h-[1.6rem] w-[1.6rem]" />
+        <span className="body2-r-17">출발지 전체</span>
+      </div>
+      <div>
+        <div className="body2-r-17 bg-gray300 flex cursor-pointer items-center px-[3.2rem] py-[0.8rem] text-black">
+          전체
+        </div>
+        {departureLocations.map((loc) => (
+          <div
+            key={loc}
+            onClick={() => handleClicklocation(loc)}
+            className="body2-r-17 hover:bg-gray100 flex cursor-pointer items-center bg-white px-[3.2rem] py-[0.8rem] text-black">
+            {loc}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DepartureModal;

--- a/src/pages/home/components/DepartureModal.tsx
+++ b/src/pages/home/components/DepartureModal.tsx
@@ -8,7 +8,7 @@ const DepartureModal = () => {
   };
 
   return (
-    <div className="border-purple100 w-[34.2rem] overflow-hidden rounded-[0.5rem] border">
+    <div className="border-purple100 w-[34.2rem] overflow-hidden rounded-[0.5rem] border shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.25)]">
       <div className="flex items-center gap-[0.8rem] px-[1.6rem] py-[2.1rem]">
         <img src={location} alt="위치 아이콘" className="text-gray600 h-[1.6rem] w-[1.6rem]" />
         <span className="body2-r-17">출발지 전체</span>

--- a/src/pages/home/components/DepartureModal.tsx
+++ b/src/pages/home/components/DepartureModal.tsx
@@ -14,7 +14,9 @@ const DepartureModal = () => {
         <span className="body2-r-17">출발지 전체</span>
       </div>
       <div>
-        <div className="body2-r-17 bg-gray300 flex cursor-pointer items-center px-[3.2rem] py-[0.8rem] text-black">
+        <div
+          onClick={() => handleClicklocation('전체')}
+          className="body2-r-17 bg-gray300 flex cursor-pointer items-center px-[3.2rem] py-[0.8rem] text-black">
           전체
         </div>
         {departureLocations.map((loc) => (


### PR DESCRIPTION
## 📌 Related Issues

- close #30 

## 📄 Tasks

### 1. 출발지 목록 배열 관리

`const departureLocations = ['인천/김포', '부산', '대구', '청주', '제주', '양양'] as const;
`

옵션으로 들어갈 출발지 목록들을 배열로 선언해놓고 map 함수를 이용해 돌리면서 구현했습니다. 
프로젝트 확장 가능성은 없지만 이렇게 해놓으면 나중에 유지보수하기가 하드코딩보다는 쉬워지리라 믿고...💁🏻 

이 컴포넌트 또한 단순 퍼블리싱이라 코드는 매우 간단합니다. 
추후에 api 연동을 해야 작동하기 때문에 현재는 옵션을 클릭하면 해당 옵션의 출발지 이름이 콘솔에 찍히도록만 설정해놓았습니다!

### 2. UI 레이아웃

- 배열 목록 div 나열
- hover시 시각화

## 📷 Screenshot

<img width="292" alt="image" src="https://github.com/user-attachments/assets/b1518cb7-8720-4c4f-8a37-015d7d28b479" />

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
