### PR TITLE
[API] Home 메인 검색 API 연동 (Tanstack-Query & Axios)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
-    "@tanstack/react-query": "^5.76.0",
+    "@tanstack/react-query": "^5.76.1",
     "@tanstack/react-query-devtools": "^5.76.0",
     "@types/react-portal": "^4.0.7",
     "@types/react-router-dom": "^5.3.3",

--- a/src/pages/home/apis/postMainSearch.ts
+++ b/src/pages/home/apis/postMainSearch.ts
@@ -1,0 +1,14 @@
+import http from '@/shared/apis/http';
+
+interface mainSearchRequest {
+  departure: string;
+  arrival: string;
+  departDate: string;
+  arriveDate: string;
+  size: number;
+}
+
+export const postMainSearch = async (body: mainSearchRequest) => {
+  const response = await http.post('/api/v1/packages/search', body);
+  return response.data;
+};

--- a/src/pages/home/apis/postMainSearchQuery.ts
+++ b/src/pages/home/apis/postMainSearchQuery.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { postMainSearch } from './postMainSearch';
+
+interface MainSearchRequest {
+  departure: string;
+  arrival: string;
+  departDate: string;
+  arriveDate: string;
+  size: number;
+}
+
+export const usePostMainSearch = () => {
+  return useMutation({
+    mutationFn: (body: MainSearchRequest) => postMainSearch(body),
+  });
+};

--- a/src/pages/home/components/CalendarModal.tsx
+++ b/src/pages/home/components/CalendarModal.tsx
@@ -7,8 +7,8 @@ import chevronRightIcon from '@/shared/assets/icons/chevronRightIcon.svg';
 import disabledChevIcon from '@/shared/assets/icons/disabledChevIcon.svg';
 
 interface DateRangeTypes {
-  arriveDate: Date | null;
   departDate: Date | null;
+  arriveDate: Date | null;
 }
 
 interface CalendarModalPropTypes {
@@ -136,8 +136,8 @@ const CalendarModal = ({ onClose, onSelectDate }: CalendarModalPropTypes) => {
     if (!startDate) return;
 
     onSelectDate({
-      arriveDate: startDate,
-      departDate: endDate ?? null,
+      departDate: startDate,
+      arriveDate: endDate ?? null,
     });
 
     onClose();

--- a/src/pages/home/components/SearchBar.tsx
+++ b/src/pages/home/components/SearchBar.tsx
@@ -10,6 +10,7 @@ import DestinationModal from './DestinationModal';
 import DepartureModal from './DepartureModal';
 import CalendarModal from './CalendarModal';
 import ModalBase from './ModalBase';
+import { usePostMainSearch } from '../apis/postMainSearchQuery';
 
 type ModalType = 'destination' | 'departure' | 'calendar' | null;
 
@@ -52,16 +53,16 @@ const SearchBar = () => {
   const [selectedArrival, setSelectedArrival] = useState<string | null>(null);
   const [selectedDeparture, setSelectedDeparture] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<{ arriveDate: Date | null; departDate: Date | null }>({
-    arriveDate: null,
     departDate: null,
+    arriveDate: null,
   });
 
   const renderDateText = () => {
-    const { arriveDate, departDate } = selectedDate;
+    const { departDate, arriveDate } = selectedDate;
 
-    if (!arriveDate) return '여행 시작일 선택';
-    if (!departDate) return formatDateString(arriveDate);
-    return `${formatDateString(arriveDate)} - ${formatDateString(departDate)}`;
+    if (!departDate) return '여행 시작일 선택';
+    if (!arriveDate) return formatDateString(departDate);
+    return `${formatDateString(departDate)} - ${formatDateString(arriveDate)}`;
   };
 
   const closeModal = () => setActiveModal(null);
@@ -115,17 +116,32 @@ const SearchBar = () => {
     }
   };
 
+  const { mutate: searchPackages } = usePostMainSearch();
+
   const handleClickSearch = () => {
-    console.log(
-      'arrival:',
-      selectedArrival,
-      '/ departure:',
-      selectedDeparture,
-      '/ arrive_date:',
-      formatDateISO(selectedDate.arriveDate),
-      '/ depart_date:',
-      formatDateISO(selectedDate.departDate)
-    );
+    if (!selectedArrival || !selectedDeparture || !selectedDate.arriveDate || !selectedDate.departDate) {
+      alert('출발지, 도착지, 날짜를 모두 선택해주세요.');
+      return;
+    }
+
+    const requestBody = {
+      departure: selectedDeparture,
+      arrival: selectedArrival,
+      departDate: formatDateISO(selectedDate.departDate) as string,
+      arriveDate: formatDateISO(selectedDate.arriveDate) as string,
+      size: 20,
+    };
+
+    searchPackages(requestBody, {
+      onSuccess: (result) => {
+        console.log('검색 결과:', result);
+      },
+      onError: (err) => {
+        console.error('패키지 검색 오류:', err);
+        alert('검색 중 오류가 발생했습니다.');
+      },
+    });
+
     localStorage.removeItem('calendar-selected-dates');
   };
 

--- a/src/pages/home/components/SearchBar.tsx
+++ b/src/pages/home/components/SearchBar.tsx
@@ -119,7 +119,7 @@ const SearchBar = () => {
   const { mutate: searchPackages } = usePostMainSearch();
 
   const handleClickSearch = () => {
-    if (!selectedArrival || !selectedDeparture || !selectedDate.arriveDate || !selectedDate.departDate) {
+    if (!selectedArrival || !selectedDeparture || !selectedDate.departDate) {
       alert('출발지, 도착지, 날짜를 모두 선택해주세요.');
       return;
     }

--- a/src/shared/apis/http.ts
+++ b/src/shared/apis/http.ts
@@ -4,7 +4,7 @@ import * as qs from 'qs';
 
 // Axios 인스턴스 생성
 const api: AxiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_BASE_URL, //추후 env에 백 배포 url 추가
+  baseURL: import.meta.env.VITE_APP_BASE_URL, //추후 env에 백 배포 url 추가
   timeout: 4000,
   headers: {
     'Content-Type': 'application/json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,7 +1092,7 @@
   dependencies:
     "@tanstack/query-devtools" "5.76.0"
 
-"@tanstack/react-query@^5.76.0":
+"@tanstack/react-query@^5.76.1":
   version "5.76.1"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.76.1.tgz#ac8a19f99dfec1452a44fe22d46680c396c21152"
   integrity sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #53 

<br/>

## 📄 Tasks

- handleClickSearch 함수에서 API 요청을 위한 body를 구성하고 mutate 실행
- React Query의 useMutation 훅이 postMainSearch API 호출을 감싸고 있음
- postMainSearch 함수는 http.post()로 실제 Axios 요청 수행
- Axios 인스턴스(http)는 axios.create()로 미리 설정되어 있으며, 기본 URL, 타임아웃, 헤더 등 기본 설정 포함 (참고)

<br/>

## ⭐ PR Point (To Reviewer)

### 1. SearchBar 컴포넌트 (SearchBar.tsx)
- 사용자가 검색 버튼을 클릭하면 searchPackages() 실행
- usePostMainSearch()에서 반환된 mutate 함수를 searchPackages로 이름 지정

```ts
const { mutate: searchPackages } = usePostMainSearch();

searchPackages(requestBody, {
  onSuccess: (result) => { ... },
  onError: (err) => { ... },
});
```

- 검색 요청 데이터 준비

```ts
const requestBody = {
  departure: selectedDeparture,
  arrival: selectedArrival,
  departDate: formatDateISO(selectedDate.departDate) as string,
  arriveDate: formatDateISO(selectedDate.arriveDate) as string,
  size: 20,
};

```

<br/>

### 2. API Hook (usePostMainSearch.ts)

```ts
import { useMutation } from '@tanstack/react-query';
import { postMainSearch } from './postMainSearch';

export const usePostMainSearch = () => {
  return useMutation({
    mutationFn: (body: MainSearchRequest) => postMainSearch(body),
  });
};
```
- useMutation은 서버에 데이터를 "보내는" (POST, PUT, DELETE) 요청에 사용
- mutationFn으로 postMainSearch 함수 등록

> 왜 useQuery가 아닌 useMutation?
>> useQuery: 데이터를 가져올 때 (GET) 사용 / 캐싱 중심
>> useMutation: 데이터를 변경할 때 (POST/PUT/DELETE) 사용. 즉시 실행, 캐시 갱신 필요 X

<br/>

### 3. API 함수 (postMainSearch.ts)
```ts
export const postMainSearch = async (body: mainSearchRequest) => {
  const response = await http.post('/api/v1/packages/search', body);
  return response.data;
};
```
- http.post()를 통해 실제 Axios 요청
- await로 응답을 받고 data만 반환

<br/>

### 4. Axios 인스턴스 설정 (http.ts | 참고)
```ts
const api = axios.create({
  baseURL: import.meta.env.VITE_APP_BASE_URL,
  timeout: 4000,
  headers: {
    'Content-Type': 'application/json',
  },
  paramsSerializer: (params) => qs.stringify(params, { indices: false }),
});
```
- axios.create()를 통해 api 인스턴스 생성

> baseURL: 환경변수에서 불러오는 기본 도메인 주소
> timeout: 4초 내 응답 없으면 에러
> Content-Type: JSON 요청 명시
> paramsSerializer: 쿼리 스트링 커스터마이징



```ts
const http: HttpClientTypes = {
  get: (url, config) => api.get(url, config),
  post: (url, data, config) => api.post(url, data, config),
  ...
};
```

- Axios 인스턴스를 http라는 이름으로 래핑하여 사용
- postMainSearch 등에서 간결하게 http.post()로 호출 가능

<br/>

### 전체 흐름

1. **handleClickSearch() 실행**
→ 사용자가 "검색" 버튼을 클릭하면 실행되며, 입력값을 확인한 뒤 `searchPackages(requestBody)`를 호출한다.

2. **searchPackages(requestBody) 실행** ← `usePostMainSearch().mutate()`
→ mutate() 함수를 통해 검색 요청을 보낸다.

3. **useMutation** → `mutationFn = postMainSearch`
→ mutate()가 실행되면 내부에서 postMainSearch() 함수가 호출된다.

4. **postMainSearch** → `http.post('/api/v1/packages/search', body)`
→ Axios 인스턴스를 이용해 /api/v1/packages/search로 POST 요청을 보낸다. 요청 데이터는 body에 담긴다.

5. **Axios 인스턴스** (baseURL 등 설정 포함)
→ 미리 설정된 Axios 인스턴스를 사용하며, 기본 URL과 헤더 정보 등이 포함되어 있다.

6. **서버 응답 → result.data 반환**
→ 서버에서 응답을 받으면 그중 data만 꺼내서 결과로 전달한다.

7. **onSuccess(result) / onError(error) 실행**
→ 요청이 성공하면 onSuccess가 실행되어 결과를 처리하고,
실패하면 onError가 실행되어 오류 메시지 출력 등 에러 처리를 한다.

<br/>

## 📷 Screenshot

<img width="1470" alt="스크린샷 2025-05-22 오전 3 38 10" src="https://github.com/user-attachments/assets/936b56fd-7ee8-43fc-b327-7b2bdcc16671" />


## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
